### PR TITLE
cloud-native-poc-kafka-email-consumer to 0.0.2

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -5,6 +5,9 @@ dependencies:
 - name: cloud-native-poc-kafka
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.12
+- name: cloud-native-poc-kafka-email-consumer
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.2
 - name: cloud-native-poc-pdf
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.25


### PR DESCRIPTION
Promote cloud-native-poc-kafka-email-consumer to version 0.0.2