### PR TITLE
cloud-native-poc-kafka-pdf-consumer to 0.0.5

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -8,6 +8,9 @@ dependencies:
 - name: cloud-native-poc-kafka-email-consumer
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.2
+- name: cloud-native-poc-kafka-pdf-consumer
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.5
 - name: cloud-native-poc-pdf
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.25


### PR DESCRIPTION
Promote cloud-native-poc-kafka-pdf-consumer to version 0.0.5