### PR TITLE
cloud-native-poc-vault to 0.0.3

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -19,7 +19,7 @@ dependencies:
   version: 0.0.25
 - name: cloud-native-poc-vault
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.2
+  version: 0.0.3
 - name: cloud-native-poc-zookeeper
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.32


### PR DESCRIPTION
Promote cloud-native-poc-vault to version 0.0.3