### PR TITLE
cloud-native-poc-mysql2 to 0.0.9

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -16,7 +16,7 @@ dependencies:
   version: 0.0.5
 - name: cloud-native-poc-mysql2
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.8
+  version: 0.0.9
 - name: cloud-native-poc-pdf
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.25


### PR DESCRIPTION
Promote cloud-native-poc-mysql2 to version 0.0.9