### PR TITLE
cloud-native-poc-kafka-email-consumer to 0.0.3

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.12
 - name: cloud-native-poc-kafka-email-consumer
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.2
+  version: 0.0.3
 - name: cloud-native-poc-kafka-exporter
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.2


### PR DESCRIPTION
Promote cloud-native-poc-kafka-email-consumer to version 0.0.3