### PR TITLE
cloud-native-poc-kafka-exporter to 0.0.3

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
   version: 0.0.3
 - name: cloud-native-poc-kafka-exporter
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.2
+  version: 0.0.3
 - name: cloud-native-poc-kafka-pdf-consumer
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.6


### PR DESCRIPTION
Promote cloud-native-poc-kafka-exporter to version 0.0.3