### PR TITLE
cloud-native-poc-kafka-pdf-consumer to 0.0.8

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -13,7 +13,7 @@ dependencies:
   version: 0.0.3
 - name: cloud-native-poc-kafka-pdf-consumer
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.7
+  version: 0.0.8
 - name: cloud-native-poc-microservice
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.2


### PR DESCRIPTION
Promote cloud-native-poc-kafka-pdf-consumer to version 0.0.8